### PR TITLE
Apply Helvetica-inspired design refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,21 +8,21 @@
   <style>
 /* === CSS Variables === */
 :root {
-  --bg-body-light: #f7f9f5;
-  --text-body-light: #555851;
-  --bg-card-light: #eef1ec;
-  --text-card-light: #5b6058;
-  --bg-header-light: #c9d1c4;
-  --text-header-light: #5c6358;
-  --accent: #9aa39a;
-  --accent-dark: #885858;
+  --bg-body-light: #ffffff;
+  --text-body-light: #000000;
+  --bg-card-light: #f5f5f5;
+  --text-card-light: #000000;
+  --bg-header-light: #ffffff;
+  --text-header-light: #000000;
+  --accent: #ff0000;
+  --accent-dark: #b00000;
 
-  --bg-body-dark: #3c3c40;
-  --text-body-dark: #f1e8dc;
-  --bg-card-dark: #574d44;
-  --text-card-dark: #e9d9c7;
-  --bg-header-dark: #5a4a3f;
-  --text-header-dark: #f1e5d7;
+  --bg-body-dark: #000000;
+  --text-body-dark: #ffffff;
+  --bg-card-dark: #1a1a1a;
+  --text-card-dark: #ffffff;
+  --bg-header-dark: #000000;
+  --text-header-dark: #ffffff;
 
   --header-font-weight: 500;
   --body-font-weight: 400;
@@ -37,8 +37,8 @@
 
 body {
   margin: 0;
-  font-family: Helvetica, Arial, sans-serif;
-  text-transform: lowercase;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  
   background-color: var(--bg-body-light);
   color: var(--text-body-light);
   line-height: 1.6;
@@ -81,8 +81,8 @@ nav {
 }
 
 nav a {
-  font-family: Helvetica, Arial, sans-serif;
-  text-transform: lowercase;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  
   font-weight: var(--nav-font-weight);
   font-size: 1rem;
   color: var(--text-header-light);
@@ -121,8 +121,8 @@ body.dark-mode .toggle-dark {
 .logo {
   display: flex;
   align-items: center;
-  font-family: Helvetica, Arial, sans-serif;
-  text-transform: lowercase;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  
   font-size: 1.5rem;
   text-decoration: none;
   color: inherit;
@@ -136,7 +136,7 @@ body.dark-mode .toggle-dark {
 .logo-text {
   font-size: 1.5rem;
   font-weight: var(--header-font-weight);
-  text-transform: lowercase;
+  
 }
 
 /* === Main and Sections === */
@@ -165,7 +165,7 @@ section + section {
 
 /* === Typography === */
 h2 {
-  font-family: Helvetica, Arial, sans-serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 1.8rem;
   margin-bottom: 1rem;
   font-weight: var(--header-font-weight);
@@ -369,12 +369,12 @@ body.dark-mode footer {
 }
 
 .viewport-links a {
-  font-family: Helvetica, Arial, sans-serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-weight: var(--nav-font-weight);
   color: var(--text-header-light);
   text-decoration: none;
   position: relative;
-  text-transform: lowercase;
+  
   transition: font-size 0.3s, font-weight 0.3s;
 }
 
@@ -414,7 +414,7 @@ body::before {
   nav a {
     margin: 0.5rem 0;
     width: 100%;
-    text-transform: lowercase;
+    
   }
 
   header {

--- a/style.css
+++ b/style.css
@@ -27,8 +27,8 @@
   
   /* Base styles */
   body {
-    font-family: Helvetica, Arial, sans-serif;
-    text-transform: lowercase;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    
     margin: 0;
     padding: 0;
     background-color: var(--background);


### PR DESCRIPTION
## Summary
- adjust CSS variables to a stark Helvetica-style palette
- use `"Helvetica Neue", Helvetica, Arial, sans-serif` throughout
- remove forced lowercase text transforms

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f5708f750832a811e6dd62c107f32