### PR TITLE
Add fade transition for navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,13 +42,17 @@ body {
   background-color: var(--bg-body-light);
   color: var(--text-body-light);
   line-height: 1.6;
-  transition: background-color 0.3s, color 0.3s;
+  transition: background-color 0.3s, color 0.3s, opacity 0.3s;
   position: relative;
 }
 
 body.dark-mode {
   background-color: var(--bg-body-dark);
   color: var(--text-body-dark);
+}
+
+.fade-out {
+  opacity: 0;
 }
 
 /* === Header and Navigation === */
@@ -573,6 +577,21 @@ body::before {
     window.history.scrollRestoration = 'manual';
     window.addEventListener('load', () => {
       setTimeout(() => window.scrollTo(0, 0), 10);
+    });
+
+    document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
+      anchor.addEventListener('click', (e) => {
+        e.preventDefault();
+        const target = anchor.getAttribute('href');
+        const originalBehavior = document.documentElement.style.scrollBehavior;
+        document.documentElement.style.scrollBehavior = 'auto';
+        document.body.classList.add('fade-out');
+        setTimeout(() => {
+          window.location.hash = target;
+          document.body.classList.remove('fade-out');
+          document.documentElement.style.scrollBehavior = originalBehavior;
+        }, 300);
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add opacity transitions for fade effects
- allow body to fade-out when navigating through hash links

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f60b037dc832aa3437a44db877d33